### PR TITLE
Fixes client.enabled: false, when field is not provided

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ type (
 
 	// ClientFields defines fields which are subject to update.
 	ClientFields struct {
-		Enabled             bool   `json:"enabled"`
+		Enabled             bool   `json:"enabled,omitempty"`
 		ScannerMode         string `json:"scanner_mode,omitempty"`
 		AttackRecheckerMode string `json:"attack_rechecker_mode,omitempty"`
 	}


### PR DESCRIPTION
When we update wallarm global mode, here no value is passed: https://github.com/wallarm/terraform-provider-wallarm/blob/master/wallarm/resource_global_mode.go#L82 therefore `false` will be passed by default.