### PR TITLE
Add attack, activity log, and security issue client support

### DIFF
--- a/activity_log.go
+++ b/activity_log.go
@@ -1,0 +1,196 @@
+package wallarm
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type (
+	// ActivityLog contains read operations available on Activity Log resources.
+	ActivityLog interface {
+		ActivityLogEventsGetFilters() (*ActivityLogEventsGetFiltersResp, error)
+		ActivityLogEventsRead(req *ActivityLogEventsRead) (*ActivityLogEventsResp, error)
+		ActivityLogEventRead(req *ActivityLogEventRead) (*ActivityLogEventsResp, error)
+	}
+
+	ActivityLogEventsGetFiltersResp struct {
+		Body ActivityLogEventsGetFiltersRespBody `json:"body"`
+	}
+
+	ActivityLogEventsGetFiltersRespBody struct {
+		ObjectTypes []ActivityLogValueLabel `json:"object_types"`
+		ActionTypes []ActivityLogValueLabel `json:"action_types"`
+		Outcomes    []string                `json:"outcomes"`
+		Sources     []string                `json:"sources"`
+	}
+
+	ActivityLogValueLabel struct {
+		Label string `json:"label"`
+		Value string `json:"value"`
+	}
+
+	ActivityLogEventsRead struct {
+		ClientID  int                      `json:"-"`
+		Filter    *ActivityLogEventsFilter `json:"filter,omitempty"`
+		Offset    int                      `json:"offset,omitempty"`
+		Limit     int                      `json:"limit,omitempty"`
+		OrderBy   string                   `json:"order_by,omitempty"`
+		OrderDesc bool                     `json:"order_desc,omitempty"`
+	}
+
+	ActivityLogEventsFilter struct {
+		ObjectTypes []string `json:"object_types,omitempty"`
+		ActionTypes []string `json:"action_types,omitempty"`
+		Outcomes    []string `json:"outcomes,omitempty"`
+		Sources     []string `json:"sources,omitempty"`
+		ActorIDs    []int64  `json:"actor_ids,omitempty"`
+		TimeStart   int64    `json:"time_start,omitempty"`
+		TimeEnd     int64    `json:"time_end,omitempty"`
+	}
+
+	ActivityLogEventRead struct {
+		ClientID int   `json:"-"`
+		EventID  int64 `json:"-"`
+	}
+
+	ActivityLogEventsResp struct {
+		Body ActivityLogEventsRespBody `json:"body"`
+	}
+
+	ActivityLogEventsRespBody struct {
+		Objects []ActivityLogEvent `json:"objects"`
+	}
+
+	ActivityLogEvent struct {
+		ID                uint64            `json:"id"`
+		Time              int64             `json:"time"`
+		ActionType        string            `json:"action_type"`
+		ObjectType        string            `json:"object_type"`
+		Outcome           string            `json:"outcome"`
+		Source            string            `json:"source"`
+		ClientID          int64             `json:"client_id"`
+		Initiator         *ActivityLogActor `json:"initiator,omitempty"`
+		ObjectID          *string           `json:"object_id,omitempty"`
+		Description       *string           `json:"description,omitempty"`
+		ChangedFields     []string          `json:"changed_fields,omitempty"`
+		Diff              json.RawMessage   `json:"diff,omitempty"`
+		StateBeforeAction json.RawMessage   `json:"state_before_action,omitempty"`
+		StateAfterAction  json.RawMessage   `json:"state_after_action,omitempty"`
+		Object            ActivityLogObject `json:"object"`
+	}
+
+	ActivityLogActor struct {
+		ID       *int64  `json:"id,omitempty"`
+		ClientID *int64  `json:"client_id,omitempty"`
+		Name     *string `json:"name,omitempty"`
+	}
+
+	ActivityLogObject struct {
+		Name string `json:"name,omitempty"`
+		Info string `json:"info,omitempty"`
+	}
+)
+
+func (api *api) ActivityLogEventsGetFilters() (*ActivityLogEventsGetFiltersResp, error) {
+	respBody, err := api.makeRequest(http.MethodGet, "/v1/activity_log/events_get_filters", "activity_log", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ActivityLogEventsGetFiltersResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) ActivityLogEventsRead(req *ActivityLogEventsRead) (*ActivityLogEventsResp, error) {
+	if req == nil {
+		return nil, fmt.Errorf("activity log request is required")
+	}
+
+	uri := fmt.Sprintf("/v1/activity_log/%d/events", req.ClientID)
+	respBody, err := api.makeRequest(http.MethodGet, uri, "activity_log", req.toQuery(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ActivityLogEventsResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) ActivityLogEventRead(req *ActivityLogEventRead) (*ActivityLogEventsResp, error) {
+	if req == nil {
+		return nil, fmt.Errorf("activity log event request is required")
+	}
+
+	uri := fmt.Sprintf("/v1/activity_log/%d/events/%d", req.ClientID, req.EventID)
+	respBody, err := api.makeRequest(http.MethodGet, uri, "activity_log", "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ActivityLogEventsResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (req *ActivityLogEventsRead) toQuery() string {
+	v := url.Values{}
+	if req == nil {
+		return v.Encode()
+	}
+
+	if req.Filter != nil {
+		for _, value := range req.Filter.ObjectTypes {
+			if value != "" {
+				v.Add("filter[object_types][]", value)
+			}
+		}
+		for _, value := range req.Filter.ActionTypes {
+			if value != "" {
+				v.Add("filter[action_types][]", value)
+			}
+		}
+		for _, value := range req.Filter.Outcomes {
+			if value != "" {
+				v.Add("filter[outcomes][]", value)
+			}
+		}
+		for _, value := range req.Filter.Sources {
+			if value != "" {
+				v.Add("filter[sources][]", value)
+			}
+		}
+		for _, actorID := range req.Filter.ActorIDs {
+			v.Add("filter[actor_ids][]", strconv.FormatInt(actorID, 10))
+		}
+		if req.Filter.TimeStart > 0 {
+			v.Set("filter[time_start]", strconv.FormatInt(req.Filter.TimeStart, 10))
+		}
+		if req.Filter.TimeEnd > 0 {
+			v.Set("filter[time_end]", strconv.FormatInt(req.Filter.TimeEnd, 10))
+		}
+	}
+
+	if req.Offset > 0 {
+		v.Set("offset", strconv.Itoa(req.Offset))
+	}
+	if req.Limit > 0 {
+		v.Set("limit", strconv.Itoa(req.Limit))
+	}
+	if req.OrderBy != "" {
+		v.Set("order_by", req.OrderBy)
+	}
+	v.Set("order_desc", strconv.FormatBool(req.OrderDesc))
+
+	return v.Encode()
+}

--- a/activity_log.go
+++ b/activity_log.go
@@ -65,21 +65,22 @@ type (
 	}
 
 	ActivityLogEvent struct {
-		ID                uint64            `json:"id"`
-		Time              int64             `json:"time"`
-		ActionType        string            `json:"action_type"`
-		ObjectType        string            `json:"object_type"`
-		Outcome           string            `json:"outcome"`
-		Source            string            `json:"source"`
-		ClientID          int64             `json:"client_id"`
-		Initiator         *ActivityLogActor `json:"initiator,omitempty"`
-		ObjectID          *string           `json:"object_id,omitempty"`
-		Description       *string           `json:"description,omitempty"`
-		ChangedFields     []string          `json:"changed_fields,omitempty"`
-		Diff              json.RawMessage   `json:"diff,omitempty"`
-		StateBeforeAction json.RawMessage   `json:"state_before_action,omitempty"`
-		StateAfterAction  json.RawMessage   `json:"state_after_action,omitempty"`
-		Object            ActivityLogObject `json:"object"`
+		ID                uint64                 `json:"id"`
+		Time              int64                  `json:"time"`
+		ActionType        string                 `json:"action_type"`
+		ObjectType        string                 `json:"object_type"`
+		ObjectTypeInfo    *ActivityLogValueLabel `json:"object_type_info,omitempty"`
+		Outcome           string                 `json:"outcome"`
+		Source            string                 `json:"source"`
+		ClientID          int64                  `json:"client_id"`
+		Initiator         *ActivityLogActor      `json:"initiator,omitempty"`
+		ObjectID          *string                `json:"object_id,omitempty"`
+		Description       *string                `json:"description,omitempty"`
+		ChangedFields     []string               `json:"changed_fields,omitempty"`
+		Diff              json.RawMessage        `json:"diff,omitempty"`
+		StateBeforeAction json.RawMessage        `json:"state_before_action,omitempty"`
+		StateAfterAction  json.RawMessage        `json:"state_after_action,omitempty"`
+		Object            ActivityLogObject      `json:"object"`
 	}
 
 	ActivityLogActor struct {

--- a/activity_log_test.go
+++ b/activity_log_test.go
@@ -1,0 +1,207 @@
+package wallarm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const activityLogFiltersResponseJSON = `{
+  "body": {
+    "object_types": [
+      {"label": "Client", "value": "client"},
+      {"label": "API token", "value": "api_token"}
+    ],
+    "action_types": [
+      {"label": "Create", "value": "create"},
+      {"label": "Mode change", "value": "mode_change"}
+    ],
+    "outcomes": ["success", "failure"],
+    "sources": ["unknown", "ui_page", "node", "api_token"]
+  }
+}`
+
+const activityLogEventsResponseJSON = `{
+  "body": {
+    "objects": [
+      {
+        "id": 101,
+        "time": 1744531200,
+        "action_type": "Create",
+        "object_type": "API token",
+        "outcome": "success",
+        "source": "api_token",
+        "client_id": 17,
+        "initiator": {
+          "id": 11,
+          "client_id": 17,
+          "name": "ops-admin"
+        },
+        "object_id": "token-uuid-1",
+        "object": {
+          "name": "CI token",
+          "info": "Used by deploy pipeline"
+        },
+        "description": "Created API token",
+        "changed_fields": ["name", "scope"],
+        "diff": {"scope": {"old": null, "new": "write"}},
+        "state_after_action": {"enabled": true}
+      }
+    ]
+  }
+}`
+
+func TestActivityLogEventsGetFilters(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/activity_log/events_get_filters", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(activityLogFiltersResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.ActivityLogEventsGetFilters()
+	require.NoError(t, err)
+
+	require.Len(t, resp.Body.ObjectTypes, 2)
+	assert.Equal(t, "client", resp.Body.ObjectTypes[0].Value)
+	assert.Equal(t, "Mode change", resp.Body.ActionTypes[1].Label)
+	assert.Equal(t, []string{"success", "failure"}, resp.Body.Outcomes)
+	assert.Equal(t, []string{"unknown", "ui_page", "node", "api_token"}, resp.Body.Sources)
+}
+
+func TestActivityLogEventsRead(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/activity_log/17/events", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, []string{"api_token", "user"}, r.URL.Query()["filter[object_types][]"])
+		assert.Equal(t, []string{"create", "mode_change"}, r.URL.Query()["filter[action_types][]"])
+		assert.Equal(t, []string{"success"}, r.URL.Query()["filter[outcomes][]"])
+		assert.Equal(t, []string{"ui_page", "api_token"}, r.URL.Query()["filter[sources][]"])
+		assert.Equal(t, []string{"11", "12"}, r.URL.Query()["filter[actor_ids][]"])
+		assert.Equal(t, "1744527600", r.URL.Query().Get("filter[time_start]"))
+		assert.Equal(t, "1744531200", r.URL.Query().Get("filter[time_end]"))
+		assert.Equal(t, "5", r.URL.Query().Get("offset"))
+		assert.Equal(t, "25", r.URL.Query().Get("limit"))
+		assert.Equal(t, "timestamp", r.URL.Query().Get("order_by"))
+		assert.Equal(t, "true", r.URL.Query().Get("order_desc"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(activityLogEventsResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.ActivityLogEventsRead(&ActivityLogEventsRead{
+		ClientID: 17,
+		Filter: &ActivityLogEventsFilter{
+			ObjectTypes: []string{"api_token", "user"},
+			ActionTypes: []string{"create", "mode_change"},
+			Outcomes:    []string{"success"},
+			Sources:     []string{"ui_page", "api_token"},
+			ActorIDs:    []int64{11, 12},
+			TimeStart:   1744527600,
+			TimeEnd:     1744531200,
+		},
+		Offset:    5,
+		Limit:     25,
+		OrderBy:   "timestamp",
+		OrderDesc: true,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Body.Objects, 1)
+	event := resp.Body.Objects[0]
+	assert.Equal(t, uint64(101), event.ID)
+	assert.Equal(t, "Create", event.ActionType)
+	assert.Equal(t, "API token", event.ObjectType)
+	assert.Equal(t, "success", event.Outcome)
+	assert.Equal(t, "api_token", event.Source)
+	assert.Equal(t, int64(17), event.ClientID)
+	require.NotNil(t, event.Initiator)
+	require.NotNil(t, event.Initiator.Name)
+	assert.Equal(t, "ops-admin", *event.Initiator.Name)
+	require.NotNil(t, event.ObjectID)
+	assert.Equal(t, "token-uuid-1", *event.ObjectID)
+	assert.Equal(t, []string{"name", "scope"}, event.ChangedFields)
+	assert.JSONEq(t, `{"scope":{"old":null,"new":"write"}}`, string(event.Diff))
+	assert.JSONEq(t, `{"enabled":true}`, string(event.StateAfterAction))
+	assert.Equal(t, "CI token", event.Object.Name)
+}
+
+func TestActivityLogEventRead(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/activity_log/23/events/777", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		if got := r.URL.RawQuery; got != "" {
+			t.Fatalf("unexpected query string %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(activityLogEventsResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.ActivityLogEventRead(&ActivityLogEventRead{
+		ClientID: 23,
+		EventID:  777,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Body.Objects, 1)
+	assert.Equal(t, uint64(101), resp.Body.Objects[0].ID)
+}
+
+func TestActivityLogEventsReadToQuery(t *testing.T) {
+	req := &ActivityLogEventsRead{
+		ClientID: 1,
+		Filter: &ActivityLogEventsFilter{
+			ObjectTypes: []string{"client"},
+			ActionTypes: []string{"delete"},
+			Outcomes:    []string{"failure"},
+			Sources:     []string{"node"},
+			ActorIDs:    []int64{44},
+			TimeStart:   100,
+			TimeEnd:     200,
+		},
+		OrderDesc: false,
+	}
+
+	values, err := url.ParseQuery(req.toQuery())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"client"}, values["filter[object_types][]"])
+	assert.Equal(t, []string{"delete"}, values["filter[action_types][]"])
+	assert.Equal(t, []string{"failure"}, values["filter[outcomes][]"])
+	assert.Equal(t, []string{"node"}, values["filter[sources][]"])
+	assert.Equal(t, []string{"44"}, values["filter[actor_ids][]"])
+	assert.Equal(t, "100", values.Get("filter[time_start]"))
+	assert.Equal(t, "200", values.Get("filter[time_end]"))
+	assert.Equal(t, "false", values.Get("order_desc"))
+}

--- a/activity_log_test.go
+++ b/activity_log_test.go
@@ -33,6 +33,7 @@ const activityLogEventsResponseJSON = `{
         "time": 1744531200,
         "action_type": "Create",
         "object_type": "API token",
+        "object_type_info": {"label": "API token", "value": "api_token"},
         "outcome": "success",
         "source": "api_token",
         "client_id": 17,
@@ -134,6 +135,9 @@ func TestActivityLogEventsRead(t *testing.T) {
 	assert.Equal(t, uint64(101), event.ID)
 	assert.Equal(t, "Create", event.ActionType)
 	assert.Equal(t, "API token", event.ObjectType)
+	require.NotNil(t, event.ObjectTypeInfo)
+	assert.Equal(t, "API token", event.ObjectTypeInfo.Label)
+	assert.Equal(t, "api_token", event.ObjectTypeInfo.Value)
 	assert.Equal(t, "success", event.Outcome)
 	assert.Equal(t, "api_token", event.Source)
 	assert.Equal(t, int64(17), event.ClientID)

--- a/attack.go
+++ b/attack.go
@@ -6,6 +6,10 @@ type (
 	Attack interface {
 		AttackRead(body *AttackReadRequest) (*AttackReadResp, error)
 		AttackCount(body *AttackCountRequest) (*AttackCountResp, error)
+		AttackIP(body *AttackIPRequest) (*AttackIPResp, error)
+		HitRead(body *HitReadRequest) (*HitReadResp, error)
+		HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error)
+		HitRaw(body *HitRawRequest) ([]byte, error)
 	}
 
 	AttackReadRequest struct {
@@ -23,9 +27,11 @@ type (
 		NotType         []string        `json:"!type,omitempty"`
 		Domain          []string        `json:"domain,omitempty"`
 		Path            []string        `json:"path,omitempty"`
+		Parameter       []string        `json:"parameter,omitempty"`
 		PoolID          []int           `json:"poolid,omitempty"`
 		IP              []string        `json:"ip,omitempty"`
-		AttackID        []string        `json:"attackid,omitempty"`
+		AttackID        interface{}     `json:"attackid,omitempty"`
+		RequestID       []string        `json:"request_id,omitempty"`
 		VulnID          []int           `json:"vulnid,omitempty"`
 		NotVulnID       interface{}     `json:"!vulnid,omitempty"`
 		Experimental    *bool           `json:"experimental,omitempty"`
@@ -86,7 +92,12 @@ type (
 	AttackCountFilter struct {
 		ClientID   []int           `json:"clientid,omitempty"`
 		Time       [][]interface{} `json:"time,omitempty"`
-		AttackID   []string        `json:"attackid,omitempty"`
+		Domain     []string        `json:"domain,omitempty"`
+		Path       []string        `json:"path,omitempty"`
+		Parameter  []string        `json:"parameter,omitempty"`
+		Type       []string        `json:"type,omitempty"`
+		RequestID  []string        `json:"request_id,omitempty"`
+		AttackID   interface{}     `json:"attackid,omitempty"`
 		StatusCode []int           `json:"statuscode,omitempty"`
 		IP         []string        `json:"ip,omitempty"`
 		ID         []string        `json:"id,omitempty"`
@@ -99,6 +110,76 @@ type (
 			Hits    float64 `json:"hits"`
 			IPs     int     `json:"ips"`
 		} `json:"body"`
+	}
+
+	AttackIPRequest struct {
+		Filter *AttackCountFilter `json:"filter"`
+	}
+
+	AttackIPResp struct {
+		Status int      `json:"status"`
+		Body   []string `json:"body"`
+	}
+
+	HitReadRequest struct {
+		Filter    interface{} `json:"filter"`
+		Limit     int         `json:"limit,omitempty"`
+		Offset    int         `json:"offset,omitempty"`
+		OrderBy   string      `json:"order_by,omitempty"`
+		OrderDesc bool        `json:"order_desc,omitempty"`
+	}
+
+	HitFilter struct {
+		ClientID    []int       `json:"clientid,omitempty"`
+		AttackID    interface{} `json:"attackid,omitempty"`
+		BlockStatus interface{} `json:"block_status,omitempty"`
+		ID          []string    `json:"id,omitempty"`
+	}
+
+	HitBody struct {
+		ID            []string `json:"id"`
+		AttackID      []string `json:"attackid"`
+		Type          string   `json:"type"`
+		IP            string   `json:"ip"`
+		StatusCode    *int     `json:"statuscode"`
+		Time          int      `json:"time"`
+		Value         string   `json:"value"`
+		RemoteCountry *string  `json:"remote_country"`
+		BlockStatus   *string  `json:"block_status"`
+		RequestID     string   `json:"request_id"`
+		Path          string   `json:"path"`
+		Domain        string   `json:"domain"`
+	}
+
+	HitReadResp struct {
+		Status int       `json:"status"`
+		Body   []HitBody `json:"body"`
+	}
+
+	HitDetailsRequest struct {
+		Filter  *HitFilter `json:"filter"`
+		Returns string     `json:"returns,omitempty"`
+	}
+
+	HitDetailsResp struct {
+		Status int              `json:"status"`
+		Body   []HitDetailsBody `json:"body"`
+	}
+
+	HitDetailsBody struct {
+		ID  []string     `json:"id"`
+		Raw HitRawDetail `json:"raw"`
+	}
+
+	HitRawDetail struct {
+		Method  string                 `json:"method"`
+		URI     string                 `json:"uri"`
+		Proto   string                 `json:"proto"`
+		Headers map[string]interface{} `json:"headers"`
+	}
+
+	HitRawRequest struct {
+		Filter *HitFilter `json:"filter"`
 	}
 )
 
@@ -126,4 +207,48 @@ func (api *api) AttackCount(body *AttackCountRequest) (*AttackCountResp, error) 
 		return nil, err
 	}
 	return &resp, nil
+}
+
+func (api *api) AttackIP(body *AttackIPRequest) (*AttackIPResp, error) {
+	uri := "/v1/objects/attack/ip"
+	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp AttackIPResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) HitRead(body *HitReadRequest) (*HitReadResp, error) {
+	uri := "/v1/objects/hit"
+	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp HitReadResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error) {
+	uri := "/v1/objects/hit/details"
+	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp HitDetailsResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) HitRaw(body *HitRawRequest) ([]byte, error) {
+	uri := "/v1/objects/hit/raw"
+	return api.makeRequest("POST", uri, "attack", body)
 }

--- a/attack.go
+++ b/attack.go
@@ -1,13 +1,15 @@
 package wallarm
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net/http"
+)
 
 type (
 	Attack interface {
 		AttackRead(body *AttackReadRequest) (*AttackReadResp, error)
 		AttackCount(body *AttackCountRequest) (*AttackCountResp, error)
 		AttackIP(body *AttackIPRequest) (*AttackIPResp, error)
-		HitRead(body *HitReadRequest) (*HitReadResp, error)
 		HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error)
 		HitRaw(body *HitRawRequest) ([]byte, error)
 	}
@@ -124,41 +126,6 @@ type (
 		Body   []string `json:"body"`
 	}
 
-	HitReadRequest struct {
-		Filter    interface{} `json:"filter"`
-		Limit     int         `json:"limit,omitempty"`
-		Offset    int         `json:"offset,omitempty"`
-		OrderBy   string      `json:"order_by,omitempty"`
-		OrderDesc bool        `json:"order_desc,omitempty"`
-	}
-
-	HitFilter struct {
-		ClientID    []int       `json:"clientid,omitempty"`
-		AttackID    interface{} `json:"attackid,omitempty"`
-		BlockStatus interface{} `json:"block_status,omitempty"`
-		ID          []string    `json:"id,omitempty"`
-	}
-
-	HitBody struct {
-		ID            []string `json:"id"`
-		AttackID      []string `json:"attackid"`
-		Type          string   `json:"type"`
-		IP            string   `json:"ip"`
-		StatusCode    *int     `json:"statuscode"`
-		Time          int      `json:"time"`
-		Value         string   `json:"value"`
-		RemoteCountry *string  `json:"remote_country"`
-		BlockStatus   *string  `json:"block_status"`
-		RequestID     string   `json:"request_id"`
-		Path          string   `json:"path"`
-		Domain        string   `json:"domain"`
-	}
-
-	HitReadResp struct {
-		Status int       `json:"status"`
-		Body   []HitBody `json:"body"`
-	}
-
 	HitDetailsRequest struct {
 		Filter  *HitFilter `json:"filter"`
 		Returns string     `json:"returns,omitempty"`
@@ -188,7 +155,8 @@ type (
 
 func (api *api) AttackRead(body *AttackReadRequest) (*AttackReadResp, error) {
 	uri := "/v1/objects/attack"
-	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
+		map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +169,8 @@ func (api *api) AttackRead(body *AttackReadRequest) (*AttackReadResp, error) {
 
 func (api *api) AttackCount(body *AttackCountRequest) (*AttackCountResp, error) {
 	uri := "/v1/objects/attack/count"
-	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
+		map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +183,8 @@ func (api *api) AttackCount(body *AttackCountRequest) (*AttackCountResp, error) 
 
 func (api *api) AttackIP(body *AttackIPRequest) (*AttackIPResp, error) {
 	uri := "/v1/objects/attack/ip"
-	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
+		map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return nil, err
 	}
@@ -225,22 +195,10 @@ func (api *api) AttackIP(body *AttackIPRequest) (*AttackIPResp, error) {
 	return &resp, nil
 }
 
-func (api *api) HitRead(body *HitReadRequest) (*HitReadResp, error) {
-	uri := "/v1/objects/hit"
-	respBody, err := api.makeRequest("POST", uri, "attack", body)
-	if err != nil {
-		return nil, err
-	}
-	var resp HitReadResp
-	if err = json.Unmarshal(respBody, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
-
 func (api *api) HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error) {
 	uri := "/v1/objects/hit/details"
-	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
+		map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return nil, err
 	}
@@ -253,5 +211,6 @@ func (api *api) HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error) {
 
 func (api *api) HitRaw(body *HitRawRequest) ([]byte, error) {
 	uri := "/v1/objects/hit/raw"
-	return api.makeRequest("POST", uri, "attack", body)
+	return api.makeRequest(http.MethodPost, uri, "attack", body,
+		map[string]string{"Content-Type": "application/json"})
 }

--- a/attack.go
+++ b/attack.go
@@ -1,0 +1,129 @@
+package wallarm
+
+import "encoding/json"
+
+type (
+	Attack interface {
+		AttackRead(body *AttackReadRequest) (*AttackReadResp, error)
+		AttackCount(body *AttackCountRequest) (*AttackCountResp, error)
+	}
+
+	AttackReadRequest struct {
+		Filter    *AttackFilter `json:"filter"`
+		Limit     int           `json:"limit"`
+		Offset    int           `json:"offset"`
+		OrderBy   string        `json:"order_by"`
+		OrderDesc bool          `json:"order_desc"`
+	}
+
+	AttackFilter struct {
+		ClientID        []int           `json:"clientid,omitempty"`
+		Time            [][]interface{} `json:"time,omitempty"`
+		Type            []string        `json:"type,omitempty"`
+		NotType         []string        `json:"!type,omitempty"`
+		Domain          []string        `json:"domain,omitempty"`
+		Path            []string        `json:"path,omitempty"`
+		PoolID          []int           `json:"poolid,omitempty"`
+		IP              []string        `json:"ip,omitempty"`
+		AttackID        []string        `json:"attackid,omitempty"`
+		VulnID          []int           `json:"vulnid,omitempty"`
+		NotVulnID       interface{}     `json:"!vulnid,omitempty"`
+		Experimental    *bool           `json:"experimental,omitempty"`
+		NotExperimental *bool           `json:"!experimental,omitempty"`
+		Threat          []int           `json:"threat,omitempty"`
+		StatusCode      []int           `json:"statuscode,omitempty"`
+		Method          []string        `json:"method,omitempty"`
+	}
+
+	AttackBody struct {
+		ID            []string    `json:"id"`
+		AttackID      string      `json:"attackid"`
+		ClientID      int         `json:"clientid"`
+		Domain        string      `json:"domain"`
+		PoolID        int         `json:"poolid"`
+		Method        string      `json:"method"`
+		Parameter     string      `json:"parameter"`
+		Path          string      `json:"path"`
+		Type          string      `json:"type"`
+		FirstTime     int         `json:"first_time"`
+		LastTime      int         `json:"last_time"`
+		Hits          int         `json:"hits"`
+		HitsCount     int         `json:"hits_count_by_filter"`
+		IPCount       int         `json:"ip_count"`
+		IPCountFilter int         `json:"ip_count_by_filter"`
+		StatusCodes   []int       `json:"statuscodes"`
+		Threat        int         `json:"threat"`
+		VulnID        interface{} `json:"vulnid"`
+		Target        string      `json:"target"`
+		VectorsCount  int         `json:"vectors_count"`
+		BlockStatus   string      `json:"block_status"`
+
+		IPTop []struct {
+			IP      string `json:"ip"`
+			Count   int    `json:"count"`
+			Country string `json:"country"`
+		} `json:"ip_top"`
+
+		CountryTop []struct {
+			Country string `json:"country"`
+			Count   int    `json:"count"`
+		} `json:"country_top"`
+
+		RecheckStatus string      `json:"recheck_status"`
+		Experimental  interface{} `json:"experimental"`
+		State         interface{} `json:"state"`
+	}
+
+	AttackReadResp struct {
+		Status int          `json:"status"`
+		Body   []AttackBody `json:"body"`
+	}
+
+	AttackCountRequest struct {
+		Filter *AttackCountFilter `json:"filter"`
+	}
+
+	AttackCountFilter struct {
+		ClientID   []int           `json:"clientid,omitempty"`
+		Time       [][]interface{} `json:"time,omitempty"`
+		AttackID   []string        `json:"attackid,omitempty"`
+		StatusCode []int           `json:"statuscode,omitempty"`
+		IP         []string        `json:"ip,omitempty"`
+		ID         []string        `json:"id,omitempty"`
+	}
+
+	AttackCountResp struct {
+		Status int `json:"status"`
+		Body   struct {
+			Attacks int     `json:"attacks"`
+			Hits    float64 `json:"hits"`
+			IPs     int     `json:"ips"`
+		} `json:"body"`
+	}
+)
+
+func (api *api) AttackRead(body *AttackReadRequest) (*AttackReadResp, error) {
+	uri := "/v1/objects/attack"
+	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp AttackReadResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) AttackCount(body *AttackCountRequest) (*AttackCountResp, error) {
+	uri := "/v1/objects/attack/count"
+	respBody, err := api.makeRequest("POST", uri, "attack", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp AttackCountResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/attack.go
+++ b/attack.go
@@ -2,6 +2,7 @@ package wallarm
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -154,6 +155,9 @@ type (
 )
 
 func (api *api) AttackRead(body *AttackReadRequest) (*AttackReadResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("attack read request is required")
+	}
 	uri := "/v1/objects/attack"
 	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
 		map[string]string{"Content-Type": "application/json"})
@@ -168,6 +172,9 @@ func (api *api) AttackRead(body *AttackReadRequest) (*AttackReadResp, error) {
 }
 
 func (api *api) AttackCount(body *AttackCountRequest) (*AttackCountResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("attack count request is required")
+	}
 	uri := "/v1/objects/attack/count"
 	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
 		map[string]string{"Content-Type": "application/json"})
@@ -182,6 +189,9 @@ func (api *api) AttackCount(body *AttackCountRequest) (*AttackCountResp, error) 
 }
 
 func (api *api) AttackIP(body *AttackIPRequest) (*AttackIPResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("attack ip request is required")
+	}
 	uri := "/v1/objects/attack/ip"
 	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
 		map[string]string{"Content-Type": "application/json"})
@@ -196,6 +206,9 @@ func (api *api) AttackIP(body *AttackIPRequest) (*AttackIPResp, error) {
 }
 
 func (api *api) HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("hit details request is required")
+	}
 	uri := "/v1/objects/hit/details"
 	respBody, err := api.makeRequest(http.MethodPost, uri, "attack", body,
 		map[string]string{"Content-Type": "application/json"})
@@ -210,6 +223,9 @@ func (api *api) HitDetails(body *HitDetailsRequest) (*HitDetailsResp, error) {
 }
 
 func (api *api) HitRaw(body *HitRawRequest) ([]byte, error) {
+	if body == nil {
+		return nil, fmt.Errorf("hit raw request is required")
+	}
 	uri := "/v1/objects/hit/raw"
 	return api.makeRequest(http.MethodPost, uri, "attack", body,
 		map[string]string{"Content-Type": "application/json"})

--- a/attack.go
+++ b/attack.go
@@ -18,6 +18,8 @@ type (
 		Offset    int           `json:"offset"`
 		OrderBy   string        `json:"order_by"`
 		OrderDesc bool          `json:"order_desc"`
+		Cursor    string        `json:"cursor,omitempty"`
+		Paging    bool          `json:"paging,omitempty"`
 	}
 
 	AttackFilter struct {
@@ -83,6 +85,7 @@ type (
 	AttackReadResp struct {
 		Status int          `json:"status"`
 		Body   []AttackBody `json:"body"`
+		Cursor string       `json:"cursor,omitempty"`
 	}
 
 	AttackCountRequest struct {

--- a/attack_test.go
+++ b/attack_test.go
@@ -77,6 +77,49 @@ const attackCountResponseJSON = `{
   }
 }`
 
+const attackIPResponseJSON = `{
+  "status": 200,
+  "body": ["11.22.33.44", "11.22.33.45"]
+}`
+
+const hitResponseJSON = `{
+  "status": 200,
+  "body": [
+    {
+      "id": ["hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"],
+      "attackid": ["attacks_test_130_202604_v_1", "3z5nB4P16C7u8Q"],
+      "type": "sqli",
+      "ip": "11.22.33.45",
+      "statuscode": 403,
+      "time": 1743531300,
+      "value": "' UNION SELECT password FROM users --",
+      "remote_country": "US",
+      "block_status": "blocked",
+      "request_id": "core-2252-login",
+      "path": "/api/v1/login",
+      "domain": "shop.example.com"
+    }
+  ]
+}`
+
+const hitDetailsResponseJSON = `{
+  "status": 200,
+  "body": [
+    {
+      "id": ["hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"],
+      "raw": {
+        "method": "POST",
+        "uri": "/api/v1/login",
+        "proto": "HTTP/1.1",
+        "headers": {
+          "host": ["shop.example.com"],
+          "content-length": 123
+        }
+      }
+    }
+  ]
+}`
+
 func TestAttackRead(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/objects/attack", func(w http.ResponseWriter, r *http.Request) {
@@ -171,4 +214,159 @@ func TestAttackCount(t *testing.T) {
 	assert.Equal(t, 621, resp.Body.Attacks)
 	assert.Equal(t, 61818.0, resp.Body.Hits)
 	assert.Equal(t, 16, resp.Body.IPs)
+}
+
+func TestAttackIP(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/objects/attack/ip", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req AttackIPRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, []int{130}, req.Filter.ClientID)
+		assert.Equal(t, []string{"11.22.33.44"}, req.Filter.IP)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(attackIPResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.AttackIP(&AttackIPRequest{
+		Filter: &AttackCountFilter{
+			ClientID: []int{130},
+			IP:       []string{"11.22.33.44"},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, resp.Status)
+	assert.Equal(t, []string{"11.22.33.44", "11.22.33.45"}, resp.Body)
+}
+
+func TestHitRead(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/objects/hit", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, float64(3), req["limit"])
+		assert.Equal(t, "time", req["order_by"])
+		assert.Equal(t, true, req["order_desc"])
+
+		filter := req["filter"].(map[string]interface{})
+		attackIDs := filter["attackid"].([]interface{})
+		firstTuple := attackIDs[0].([]interface{})
+		assert.Equal(t, "attacks_test_130_202604_v_1", firstTuple[0])
+		assert.Equal(t, "3z5nB4P16C7u8Q", firstTuple[1])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(hitResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.HitRead(&HitReadRequest{
+		Filter: HitFilter{
+			ClientID: []int{130},
+			AttackID: [][]string{{"attacks_test_130_202604_v_1", "3z5nB4P16C7u8Q"}},
+		},
+		Limit:     3,
+		OrderBy:   "time",
+		OrderDesc: true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, resp.Status)
+	require.Len(t, resp.Body, 1)
+	assert.Equal(t, []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}, resp.Body[0].ID)
+	assert.Equal(t, "11.22.33.45", resp.Body[0].IP)
+	if assert.NotNil(t, resp.Body[0].StatusCode) {
+		assert.Equal(t, 403, *resp.Body[0].StatusCode)
+	}
+}
+
+func TestHitDetails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/objects/hit/details", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req HitDetailsRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}, req.Filter.ID)
+		assert.Equal(t, "raw", req.Returns)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(hitDetailsResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.HitDetails(&HitDetailsRequest{
+		Filter:  &HitFilter{ID: []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}},
+		Returns: "raw",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, resp.Status)
+	require.Len(t, resp.Body, 1)
+	assert.Equal(t, "POST", resp.Body[0].Raw.Method)
+	assert.Equal(t, "/api/v1/login", resp.Body[0].Raw.URI)
+	assert.Equal(t, "HTTP/1.1", resp.Body[0].Raw.Proto)
+}
+
+func TestHitRaw(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/objects/hit/raw", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req HitRawRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}, req.Filter.ID)
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte("raw-hit-payload"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.HitRaw(&HitRawRequest{
+		Filter: &HitFilter{ID: []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte("raw-hit-payload"), resp)
 }

--- a/attack_test.go
+++ b/attack_test.go
@@ -373,3 +373,28 @@ func TestHitRaw(t *testing.T) {
 
 	assert.Equal(t, []byte("raw-hit-payload"), resp)
 }
+
+func TestAttackMethodsRejectNilRequest(t *testing.T) {
+	client, err := New()
+	require.NoError(t, err)
+
+	respRead, err := client.AttackRead(nil)
+	require.EqualError(t, err, "attack read request is required")
+	assert.Nil(t, respRead)
+
+	respCount, err := client.AttackCount(nil)
+	require.EqualError(t, err, "attack count request is required")
+	assert.Nil(t, respCount)
+
+	respIP, err := client.AttackIP(nil)
+	require.EqualError(t, err, "attack ip request is required")
+	assert.Nil(t, respIP)
+
+	respDetails, err := client.HitDetails(nil)
+	require.EqualError(t, err, "hit details request is required")
+	assert.Nil(t, respDetails)
+
+	respRaw, err := client.HitRaw(nil)
+	require.EqualError(t, err, "hit raw request is required")
+	assert.Nil(t, respRaw)
+}

--- a/attack_test.go
+++ b/attack_test.go
@@ -258,7 +258,7 @@ func TestAttackIP(t *testing.T) {
 	assert.Equal(t, []string{"11.22.33.44", "11.22.33.45"}, resp.Body)
 }
 
-func TestHitRead(t *testing.T) {
+func TestHitReadWithAttackIDTupleFilter(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/objects/hit", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
@@ -290,8 +290,8 @@ func TestHitRead(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := client.HitRead(&HitReadRequest{
-		Filter: HitFilter{
-			ClientID: []int{130},
+		Filter: &HitFilter{
+			ClientID: 130,
 			AttackID: [][]string{{"attacks_test_130_202604_v_1", "3z5nB4P16C7u8Q"}},
 		},
 		Limit:     3,
@@ -300,13 +300,10 @@ func TestHitRead(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 200, resp.Status)
-	require.Len(t, resp.Body, 1)
-	assert.Equal(t, []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}, resp.Body[0].ID)
-	assert.Equal(t, "11.22.33.45", resp.Body[0].IP)
-	if assert.NotNil(t, resp.Body[0].StatusCode) {
-		assert.Equal(t, 403, *resp.Body[0].StatusCode)
-	}
+	require.Len(t, resp, 1)
+	assert.Equal(t, []string{"hits_test_130_202604_v_1", "Vr0ix9J6f5Wgk3dS"}, resp[0].ID)
+	assert.Equal(t, "11.22.33.45", resp[0].IP)
+	assert.Equal(t, 403, resp[0].StatusCode)
 }
 
 func TestHitDetails(t *testing.T) {

--- a/attack_test.go
+++ b/attack_test.go
@@ -1,0 +1,174 @@
+package wallarm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const attackResponseJSON = `{
+  "status": 200,
+  "body": [
+    {
+      "id": ["attacks_production_2_202603_v_1", "AM5CP50BU-M_02QxawVC"],
+      "attackid": "attacks_production_2_202603_v_1:AM5CP50BU-M_02QxawVC",
+      "clientid": 2,
+      "domain": "node-data.audit.wallarm.com",
+      "poolid": -1,
+      "method": "GET",
+      "parameter": "GET_filename_value",
+      "path": "/log/view",
+      "type": "ptrav",
+      "first_time": 1774882806,
+      "last_time": 1774892699,
+      "hits": 111,
+      "ip_count": 1,
+      "ip_top": [{"ip": "161.97.68.155", "count": 111, "country": "FR"}],
+      "country_top": [{"country": "FR", "count": 111}],
+      "statuscodes": [200, 404],
+      "vulnid": null,
+      "threat": 90,
+      "target": "server",
+      "experimental": null,
+      "recheck_status": "unrecheckable",
+      "vectors_count": 43,
+      "block_status": "monitored",
+      "state": null
+    },
+    {
+      "id": ["attacks_production_2_202603_v_1", "BN6DQ61CU-N_13RybyWD"],
+      "attackid": "attacks_production_2_202603_v_1:BN6DQ61CU-N_13RybyWD",
+      "clientid": 2,
+      "domain": "api.audit.wallarm.com",
+      "poolid": 5,
+      "method": "POST",
+      "parameter": "POST_body_value",
+      "path": "/v1/login",
+      "type": "sqli",
+      "first_time": 1774880000,
+      "last_time": 1774885000,
+      "hits": 42,
+      "ip_count": 3,
+      "ip_top": [{"ip": "10.0.0.1", "count": 30, "country": "US"}],
+      "country_top": [{"country": "US", "count": 30}],
+      "statuscodes": [403],
+      "vulnid": null,
+      "threat": 80,
+      "target": "server",
+      "experimental": null,
+      "recheck_status": "in_progress",
+      "vectors_count": 5,
+      "block_status": "blocked",
+      "state": null
+    }
+  ]
+}`
+
+const attackCountResponseJSON = `{
+  "status": 200,
+  "body": {
+    "attacks": 621,
+    "hits": 61818.0,
+    "ips": 16
+  }
+}`
+
+func TestAttackRead(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/objects/attack", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req AttackReadRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, 2, req.Limit)
+		assert.Equal(t, "last_time", req.OrderBy)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(attackResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.AttackRead(&AttackReadRequest{
+		Filter: &AttackFilter{
+			ClientID: []int{2},
+			Time:     [][]interface{}{{1774800000, nil}},
+		},
+		Limit:     2,
+		Offset:    0,
+		OrderBy:   "last_time",
+		OrderDesc: true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, resp.Status)
+	require.Len(t, resp.Body, 2)
+
+	atk := resp.Body[0]
+	assert.Equal(t, "attacks_production_2_202603_v_1:AM5CP50BU-M_02QxawVC", atk.AttackID)
+	assert.Equal(t, "node-data.audit.wallarm.com", atk.Domain)
+	assert.Equal(t, "/log/view", atk.Path)
+	assert.Equal(t, "ptrav", atk.Type)
+	assert.Equal(t, "GET", atk.Method)
+	assert.Equal(t, 111, atk.Hits)
+	assert.Equal(t, 1, atk.IPCount)
+	assert.Equal(t, 90, atk.Threat)
+	assert.Equal(t, 1774882806, atk.FirstTime)
+	assert.Equal(t, 1774892699, atk.LastTime)
+	assert.Equal(t, 2, atk.ClientID)
+	assert.Equal(t, -1, atk.PoolID)
+	assert.Equal(t, "server", atk.Target)
+	assert.Equal(t, 43, atk.VectorsCount)
+	assert.Equal(t, "monitored", atk.BlockStatus)
+	assert.Equal(t, "GET_filename_value", atk.Parameter)
+
+	atk2 := resp.Body[1]
+	assert.Equal(t, "sqli", atk2.Type)
+	assert.Equal(t, "api.audit.wallarm.com", atk2.Domain)
+	assert.Equal(t, 42, atk2.Hits)
+	assert.Equal(t, "blocked", atk2.BlockStatus)
+}
+
+func TestAttackCount(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/objects/attack/count", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(attackCountResponseJSON))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.AttackCount(&AttackCountRequest{
+		Filter: &AttackCountFilter{
+			ClientID: []int{2},
+			Time:     [][]interface{}{{1774800000, nil}},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 200, resp.Status)
+	assert.Equal(t, 621, resp.Body.Attacks)
+	assert.Equal(t, 61818.0, resp.Body.Hits)
+	assert.Equal(t, 16, resp.Body.IPs)
+}

--- a/attack_test.go
+++ b/attack_test.go
@@ -12,6 +12,7 @@ import (
 
 const attackResponseJSON = `{
   "status": 200,
+  "cursor": "cursor-2",
   "body": [
     {
       "id": ["attacks_production_2_202603_v_1", "AM5CP50BU-M_02QxawVC"],
@@ -131,6 +132,8 @@ func TestAttackRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 2, req.Limit)
 		assert.Equal(t, "last_time", req.OrderBy)
+		assert.Equal(t, "cursor-1", req.Cursor)
+		assert.True(t, req.Paging)
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(attackResponseJSON))
@@ -154,10 +157,13 @@ func TestAttackRead(t *testing.T) {
 		Offset:    0,
 		OrderBy:   "last_time",
 		OrderDesc: true,
+		Cursor:    "cursor-1",
+		Paging:    true,
 	})
 	require.NoError(t, err)
 
 	assert.Equal(t, 200, resp.Status)
+	assert.Equal(t, "cursor-2", resp.Cursor)
 	require.Len(t, resp.Body, 2)
 
 	atk := resp.Body[0]

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type (
 	API interface {
 		Action
 		Application
+		Attack
 		IPList
 		Allowlist
 		Graylist

--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type (
 		CredentialStuffingConfigs
 		SecurityIssues
 		Hits
+		ActivityLog
 	}
 
 	api struct {

--- a/get_hits.go
+++ b/get_hits.go
@@ -30,6 +30,7 @@ type (
 		RequestID         string          `json:"request_id,omitempty"`
 		ID                []string        `json:"id,omitempty"`
 		AttackID          [][]string      `json:"attackid,omitempty"`
+		BlockStatus       []string        `json:"block_status,omitempty"`
 		Type              []string        `json:"type,omitempty"`
 		State             *string         `json:"state"`
 		NotType           []string        `json:"!type,omitempty"`

--- a/get_security_issues.go
+++ b/get_security_issues.go
@@ -206,6 +206,9 @@ type (
 )
 
 func (api *api) GetSecurityIssuesRead(body *GetSecurityIssuesRead) ([]*GetSecurityIssuesResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("security issues read request is required")
+	}
 	request := *body
 	request.Token = api.attackSurfaceToken(request.Token)
 
@@ -222,6 +225,9 @@ func (api *api) GetSecurityIssuesRead(body *GetSecurityIssuesRead) ([]*GetSecuri
 }
 
 func (api *api) GetSecurityIssuesCount(body *GetSecurityIssuesCount) (*GetSecurityIssuesCountResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("security issues count request is required")
+	}
 	request := *body
 	request.Token = api.attackSurfaceToken(request.Token)
 
@@ -238,6 +244,9 @@ func (api *api) GetSecurityIssuesCount(body *GetSecurityIssuesCount) (*GetSecuri
 }
 
 func (api *api) GetSecurityIssueGroups(body *GetSecurityIssueGroups) ([]*GetSecurityIssueGroupResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("security issue groups request is required")
+	}
 	request := *body
 	request.Token = api.attackSurfaceToken(request.Token)
 
@@ -254,6 +263,9 @@ func (api *api) GetSecurityIssueGroups(body *GetSecurityIssueGroups) ([]*GetSecu
 }
 
 func (api *api) GetSecurityIssueGroupsCount(body *GetSecurityIssueGroupsCount) (*GetSecurityIssueGroupsCountResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("security issue groups count request is required")
+	}
 	request := *body
 	request.Token = api.attackSurfaceToken(request.Token)
 
@@ -270,6 +282,9 @@ func (api *api) GetSecurityIssueGroupsCount(body *GetSecurityIssueGroupsCount) (
 }
 
 func (api *api) GetSecurityIssue(body *GetSecurityIssue) (*GetSecurityIssueResp, error) {
+	if body == nil {
+		return nil, fmt.Errorf("security issue request is required")
+	}
 	query := url.Values{}
 	query.Set("client_id", fmt.Sprintf("%d", body.ClientID))
 	query.Set("token", api.attackSurfaceToken(body.Token))

--- a/get_security_issues.go
+++ b/get_security_issues.go
@@ -162,19 +162,19 @@ type (
 	}
 
 	GetSecurityIssueGroupResp struct {
-		GroupID                 string                `json:"group_id"`
-		Title                   string                `json:"title"`
-		Severity                string                `json:"severity"`
-		DiscoveredBy            string                `json:"discovered_by"`
-		DiscoveredByDisplayName string                `json:"discovered_by_display_name"`
-		IssueType               SecurityIssueType     `json:"issue_type"`
-		SecurityIssuesCount     int                   `json:"security_issues_count"`
-		States                  SecurityIssueStates   `json:"states"`
-		Owasp                   []SecurityIssueOWASP  `json:"owasp"`
-		HostsCount              int                   `json:"hosts_count"`
-		FirstHost               string                `json:"first_host"`
-		ClientID                int                   `json:"client_id"`
-		Tags                    []SecurityIssueTag    `json:"tags"`
+		GroupID                 string               `json:"group_id"`
+		Title                   string               `json:"title"`
+		Severity                string               `json:"severity"`
+		DiscoveredBy            string               `json:"discovered_by"`
+		DiscoveredByDisplayName string               `json:"discovered_by_display_name"`
+		IssueType               SecurityIssueType    `json:"issue_type"`
+		SecurityIssuesCount     int                  `json:"security_issues_count"`
+		States                  SecurityIssueStates  `json:"states"`
+		Owasp                   []SecurityIssueOWASP `json:"owasp"`
+		HostsCount              int                  `json:"hosts_count"`
+		FirstHost               string               `json:"first_host"`
+		ClientID                int                  `json:"client_id"`
+		Tags                    []SecurityIssueTag   `json:"tags"`
 	}
 
 	GetSecurityIssueGroupsCountResp struct {
@@ -183,25 +183,25 @@ type (
 
 	GetSecurityIssueResp struct {
 		GetSecurityIssuesResp
-		Credentials          []string         `json:"credentials"`
-		AdditionalInfo       string           `json:"additional_info"`
-		ExploitationExamples []interface{}    `json:"exploitation_examples"`
-		OOBInteraction       []interface{}    `json:"oob_interaction"`
-		PassiveDetectIncident bool            `json:"passive_detect_incident"`
-		Description          string           `json:"description"`
-		References           []string         `json:"references"`
-		Mitigation           string           `json:"mitigation"`
-		CWE                  []interface{}    `json:"cwe"`
-		RiskInfo             map[string]interface{} `json:"risk_info"`
-		Source               string           `json:"source"`
-		IssueSubtype         map[string]interface{} `json:"issue_subtype"`
-		PassiveDetectURLs    []string         `json:"passive_detect_urls"`
-		Manual               bool             `json:"manual"`
-		LeaksInfo            []interface{}    `json:"leaks_info"`
-		URLActive            bool             `json:"url_active"`
-		StatusHistory        []map[string]interface{} `json:"status_history"`
-		Recheckable          bool             `json:"recheckable"`
-		LastRecheck          map[string]interface{} `json:"last_recheck"`
+		Credentials           []string                 `json:"credentials"`
+		AdditionalInfo        string                   `json:"additional_info"`
+		ExploitationExamples  []interface{}            `json:"exploitation_examples"`
+		OOBInteraction        []interface{}            `json:"oob_interaction"`
+		PassiveDetectIncident bool                     `json:"passive_detect_incident"`
+		Description           string                   `json:"description"`
+		References            []string                 `json:"references"`
+		Mitigation            string                   `json:"mitigation"`
+		CWE                   []interface{}            `json:"cwe"`
+		RiskInfo              map[string]interface{}   `json:"risk_info"`
+		Source                string                   `json:"source"`
+		IssueSubtype          map[string]interface{}   `json:"issue_subtype"`
+		PassiveDetectURLs     []string                 `json:"passive_detect_urls"`
+		Manual                bool                     `json:"manual"`
+		LeaksInfo             []interface{}            `json:"leaks_info"`
+		URLActive             bool                     `json:"url_active"`
+		StatusHistory         []map[string]interface{} `json:"status_history"`
+		Recheckable           bool                     `json:"recheckable"`
+		LastRecheck           map[string]interface{}   `json:"last_recheck"`
 	}
 )
 

--- a/get_security_issues.go
+++ b/get_security_issues.go
@@ -2,25 +2,60 @@ package wallarm
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
+var securityIssuesJSONHeaders = map[string]string{"Content-Type": "application/json"}
+
 type (
-	// SecurityIssues contains operations available on SecurityIssues resource
+	// SecurityIssues contains read operations available on Security Issues resources.
 	SecurityIssues interface {
-		GetSecurityIssuesRead(getSecurityIssuesBody *GetSecurityIssuesRead) ([]*GetSecurityIssuesResp, error)
+		GetSecurityIssuesRead(body *GetSecurityIssuesRead) ([]*GetSecurityIssuesResp, error)
+		GetSecurityIssuesCount(body *GetSecurityIssuesCount) (*GetSecurityIssuesCountResp, error)
+		GetSecurityIssueGroups(body *GetSecurityIssueGroups) ([]*GetSecurityIssueGroupResp, error)
+		GetSecurityIssueGroupsCount(body *GetSecurityIssueGroupsCount) (*GetSecurityIssueGroupsCountResp, error)
+		GetSecurityIssue(body *GetSecurityIssue) (*GetSecurityIssueResp, error)
 	}
 
-	// GetSecurityIssuesRead is a root object for requesting security issues.
-	// Limit is a number between 0 - 1000
-	// Offset is a number
 	GetSecurityIssuesRead struct {
 		ClientID  int                       `json:"client_id"`
-		Offset    int                       `json:"offset"`
-		Limit     int                       `json:"limit"`
-		Unlimited bool                      `json:"unlimited"`
-		Filter    *GetSecurityIssuesFilter  `json:"filter"`
-		OrderBy   *GetSecurityIssuesOrderBy `json:"order_by"`
+		Token     string                    `json:"token,omitempty"`
+		Offset    int                       `json:"offset,omitempty"`
+		Limit     int                       `json:"limit,omitempty"`
+		Unlimited bool                      `json:"unlimited,omitempty"`
+		Filter    *GetSecurityIssuesFilter  `json:"filter,omitempty"`
+		OrderBy   *GetSecurityIssuesOrderBy `json:"order_by,omitempty"`
+	}
+
+	GetSecurityIssuesCount struct {
+		ClientID int                      `json:"client_id"`
+		Token    string                   `json:"token,omitempty"`
+		Filter   *GetSecurityIssuesFilter `json:"filter,omitempty"`
+	}
+
+	GetSecurityIssueGroups struct {
+		ClientID  int                       `json:"client_id"`
+		Token     string                    `json:"token,omitempty"`
+		Offset    int                       `json:"offset,omitempty"`
+		Limit     int                       `json:"limit,omitempty"`
+		Unlimited bool                      `json:"unlimited,omitempty"`
+		Filter    *GetSecurityIssuesFilter  `json:"filter,omitempty"`
+		OrderBy   *GetSecurityIssuesOrderBy `json:"order_by,omitempty"`
+	}
+
+	GetSecurityIssueGroupsCount struct {
+		ClientID int                      `json:"client_id"`
+		Token    string                   `json:"token,omitempty"`
+		Filter   *GetSecurityIssuesFilter `json:"filter,omitempty"`
+	}
+
+	GetSecurityIssue struct {
+		ID       int
+		ClientID int
+		Token    string
 	}
 
 	GetSecurityIssuesOrderBy struct {
@@ -29,8 +64,8 @@ type (
 	}
 
 	GetSecurityIssuesFilter struct {
-		ClientId           int      `json:"client_id,omitempty"`
-		NotClientId        int      `json:"!client_id,omitempty"`
+		ClientID           int      `json:"client_id,omitempty"`
+		NotClientID        int      `json:"!client_id,omitempty"`
 		Severity           []string `json:"severity,omitempty"`
 		NotSeverity        []string `json:"!severity,omitempty"`
 		Host               string   `json:"host,omitempty"`
@@ -41,78 +76,233 @@ type (
 		DiscoveredSince    int      `json:"discovered_since,omitempty"`
 		DiscoveredBy       []string `json:"discovered_by,omitempty"`
 		NotDiscoveredBy    []string `json:"!discovered_by,omitempty"`
-		Id                 int      `json:"id,omitempty"`
-		NotId              int      `json:"!id,omitempty"`
-		DomainId           int      `json:"domain_id,omitempty"`
-		NotDomainId        int      `json:"!domain_id,omitempty"`
-		SubdomainId        int      `json:"subdomain_id,omitempty"`
-		NotSubdomainId     int      `json:"!subdomain_id,omitempty"`
+		ID                 int      `json:"id,omitempty"`
+		NotID              int      `json:"!id,omitempty"`
+		DomainID           int      `json:"domain_id,omitempty"`
+		NotDomainID        int      `json:"!domain_id,omitempty"`
+		SubdomainID        int      `json:"subdomain_id,omitempty"`
+		NotSubdomainID     int      `json:"!subdomain_id,omitempty"`
 		IssueType          string   `json:"issue_type,omitempty"`
 		NotIssueType       string   `json:"!issue_type,omitempty"`
 		Owasp              string   `json:"owasp,omitempty"`
 		NotOwasp           string   `json:"!owasp,omitempty"`
 		SourceTemplate     string   `json:"source_template,omitempty"`
 		NotSourceTemplate  string   `json:"!source_template,omitempty"`
-		GroupId            string   `json:"group_id,omitempty"`
-		NotGroupId         string   `json:"!group_id,omitempty"`
+		GroupID            string   `json:"group_id,omitempty"`
+		NotGroupID         string   `json:"!group_id,omitempty"`
 		SearchQuery        string   `json:"search_query,omitempty"`
 		TestRunPublicUuids string   `json:"test_run_public_uuids,omitempty"`
 		Verified           bool     `json:"verified,omitempty"`
+		Incident           *bool    `json:"incident,omitempty"`
+	}
+
+	SecurityIssueType struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	SecurityIssueOWASP struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+		Link     string `json:"link"`
+	}
+
+	SecurityIssueTag struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	}
+
+	SecurityIssueVPatch struct {
+		RuleID *int `json:"rule_id"`
+	}
+
+	SecurityIssueMitigations struct {
+		Vpatch *SecurityIssueVPatch `json:"vpatch,omitempty"`
 	}
 
 	GetSecurityIssuesResp struct {
-		Id                      int    `json:"id"`
-		ClientId                int    `json:"client_id"`
-		Severity                string `json:"severity"`
-		State                   string `json:"state"`
-		Volume                  int    `json:"volume"`
-		Name                    string `json:"name"`
-		CreatedAt               int    `json:"created_at"`
-		DiscoveredAt            int    `json:"discovered_at"`
-		DiscoveredBy            string `json:"discovered_by"`
-		DiscoveredByDisplayName string `json:"discovered_by_display_name"`
-		Url                     string `json:"url"`
-		Host                    string `json:"host"`
-		Path                    string `json:"path"`
-		ParameterDisplayName    string `json:"parameter_display_name"`
-		ParameterPosition       string `json:"parameter_position"`
-		ParameterName           string `json:"parameter_name"`
-		HttpMethod              string `json:"http_method"`
-		AasmTemplate            string `json:"aasm_template"`
-		Mitigations             struct {
-			Vpatch struct {
-				RuleId int `json:"rule_id"`
-			} `json:"vpatch"`
-		} `json:"mitigations"`
-		IssueType struct {
-			Id   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"issue_type"`
-		Owasp []struct {
-			Id       string `json:"id"`
-			Name     string `json:"name"`
-			FullName string `json:"full_name"`
-			Link     string `json:"link"`
-		} `json:"owasp"`
-		Tags []struct {
-			Id   int    `json:"id"`
-			Name string `json:"name"`
-			Slug string `json:"slug"`
-		} `json:"tags"`
-		Verified bool `json:"verified"`
+		ID                      int                      `json:"id"`
+		ClientID                int                      `json:"client_id"`
+		Severity                string                   `json:"severity"`
+		State                   string                   `json:"state"`
+		Volume                  int                      `json:"volume"`
+		Name                    string                   `json:"name"`
+		CreatedAt               int                      `json:"created_at"`
+		DiscoveredAt            int                      `json:"discovered_at"`
+		DiscoveredBy            string                   `json:"discovered_by"`
+		DiscoveredByDisplayName string                   `json:"discovered_by_display_name"`
+		URL                     string                   `json:"url"`
+		Host                    string                   `json:"host"`
+		Path                    string                   `json:"path"`
+		ParameterDisplayName    string                   `json:"parameter_display_name"`
+		ParameterPosition       string                   `json:"parameter_position"`
+		ParameterName           string                   `json:"parameter_name"`
+		HTTPMethod              string                   `json:"http_method"`
+		AASMTemplate            string                   `json:"aasm_template"`
+		Mitigations             SecurityIssueMitigations `json:"mitigations"`
+		IssueType               SecurityIssueType        `json:"issue_type"`
+		Owasp                   []SecurityIssueOWASP     `json:"owasp"`
+		Tags                    []SecurityIssueTag       `json:"tags"`
+		Incident                bool                     `json:"incident"`
+		FalsePositiveRuleID     *int                     `json:"false_positive_rule_id"`
+		Verified                bool                     `json:"verified"`
+	}
+
+	GetSecurityIssuesCountResp struct {
+		Count int `json:"count"`
+	}
+
+	SecurityIssueStates struct {
+		Open        int `json:"open"`
+		Closed      int `json:"closed"`
+		MarkedFalse int `json:"marked_false"`
+		Hidden      int `json:"hidden,omitempty"`
+	}
+
+	GetSecurityIssueGroupResp struct {
+		GroupID                 string                `json:"group_id"`
+		Title                   string                `json:"title"`
+		Severity                string                `json:"severity"`
+		DiscoveredBy            string                `json:"discovered_by"`
+		DiscoveredByDisplayName string                `json:"discovered_by_display_name"`
+		IssueType               SecurityIssueType     `json:"issue_type"`
+		SecurityIssuesCount     int                   `json:"security_issues_count"`
+		States                  SecurityIssueStates   `json:"states"`
+		Owasp                   []SecurityIssueOWASP  `json:"owasp"`
+		HostsCount              int                   `json:"hosts_count"`
+		FirstHost               string                `json:"first_host"`
+		ClientID                int                   `json:"client_id"`
+		Tags                    []SecurityIssueTag    `json:"tags"`
+	}
+
+	GetSecurityIssueGroupsCountResp struct {
+		Count int `json:"count"`
+	}
+
+	GetSecurityIssueResp struct {
+		GetSecurityIssuesResp
+		Credentials          []string         `json:"credentials"`
+		AdditionalInfo       string           `json:"additional_info"`
+		ExploitationExamples []interface{}    `json:"exploitation_examples"`
+		OOBInteraction       []interface{}    `json:"oob_interaction"`
+		PassiveDetectIncident bool            `json:"passive_detect_incident"`
+		Description          string           `json:"description"`
+		References           []string         `json:"references"`
+		Mitigation           string           `json:"mitigation"`
+		CWE                  []interface{}    `json:"cwe"`
+		RiskInfo             map[string]interface{} `json:"risk_info"`
+		Source               string           `json:"source"`
+		IssueSubtype         map[string]interface{} `json:"issue_subtype"`
+		PassiveDetectURLs    []string         `json:"passive_detect_urls"`
+		Manual               bool             `json:"manual"`
+		LeaksInfo            []interface{}    `json:"leaks_info"`
+		URLActive            bool             `json:"url_active"`
+		StatusHistory        []map[string]interface{} `json:"status_history"`
+		Recheckable          bool             `json:"recheckable"`
+		LastRecheck          map[string]interface{} `json:"last_recheck"`
 	}
 )
 
-func (api *api) GetSecurityIssuesRead(getSecurityIssuesBody *GetSecurityIssuesRead) ([]*GetSecurityIssuesResp, error) {
-	uri := "/v1/security_issues"
-	respBody, err := api.makeRequest(http.MethodGet, uri, "security_issues", getSecurityIssuesBody,
-		map[string]string{"Content-Type": "application/json"})
+func (api *api) GetSecurityIssuesRead(body *GetSecurityIssuesRead) ([]*GetSecurityIssuesResp, error) {
+	request := *body
+	request.Token = api.attackSurfaceToken(request.Token)
+
+	respBody, err := api.makeRequest(http.MethodPost, "/v1/security_issues", "security_issues", &request, securityIssuesJSONHeaders)
 	if err != nil {
 		return nil, err
 	}
-	var v []*GetSecurityIssuesResp
-	if err = json.Unmarshal(respBody, &v); err != nil {
+
+	var resp []*GetSecurityIssuesResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
 		return nil, err
 	}
-	return v, nil
+	return resp, nil
+}
+
+func (api *api) GetSecurityIssuesCount(body *GetSecurityIssuesCount) (*GetSecurityIssuesCountResp, error) {
+	request := *body
+	request.Token = api.attackSurfaceToken(request.Token)
+
+	respBody, err := api.makeRequest(http.MethodPost, "/v1/security_issues/count", "security_issues", &request, securityIssuesJSONHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GetSecurityIssuesCountResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) GetSecurityIssueGroups(body *GetSecurityIssueGroups) ([]*GetSecurityIssueGroupResp, error) {
+	request := *body
+	request.Token = api.attackSurfaceToken(request.Token)
+
+	respBody, err := api.makeRequest(http.MethodPost, "/v1/security_issues/groups", "security_issues", &request, securityIssuesJSONHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []*GetSecurityIssueGroupResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (api *api) GetSecurityIssueGroupsCount(body *GetSecurityIssueGroupsCount) (*GetSecurityIssueGroupsCountResp, error) {
+	request := *body
+	request.Token = api.attackSurfaceToken(request.Token)
+
+	respBody, err := api.makeRequest(http.MethodPost, "/v1/security_issues/groups_count", "security_issues", &request, securityIssuesJSONHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GetSecurityIssueGroupsCountResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) GetSecurityIssue(body *GetSecurityIssue) (*GetSecurityIssueResp, error) {
+	query := url.Values{}
+	query.Set("client_id", fmt.Sprintf("%d", body.ClientID))
+	query.Set("token", api.attackSurfaceToken(body.Token))
+
+	respBody, err := api.makeRequest(http.MethodGet, fmt.Sprintf("/v1/security_issues/%d", body.ID), "security_issues", query.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GetSecurityIssueResp
+	if err = json.Unmarshal(respBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (api *api) attackSurfaceToken(explicit string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return strings.TrimSpace(explicit)
+	}
+	if token := api.headers.Get("X-WallarmAPI-Token"); strings.TrimSpace(token) != "" {
+		return strings.TrimSpace(token)
+	}
+	if token := api.headers.Get("X-WallarmApi-Token"); strings.TrimSpace(token) != "" {
+		return strings.TrimSpace(token)
+	}
+	for name, values := range api.headers {
+		if !(strings.EqualFold(name, "X-WallarmAPI-Token") || strings.EqualFold(name, "X-WallarmApi-Token")) {
+			continue
+		}
+		if len(values) > 0 && strings.TrimSpace(values[0]) != "" {
+			return strings.TrimSpace(values[0])
+		}
+	}
+	return ""
 }

--- a/get_security_issues_test.go
+++ b/get_security_issues_test.go
@@ -148,3 +148,28 @@ func TestGetSecurityIssueUsesGETQueryTokenAndClientID(t *testing.T) {
 	assert.Equal(t, 101, resp.ID)
 	assert.Equal(t, "demo issue", resp.Description)
 }
+
+func TestSecurityIssueMethodsRejectNilRequest(t *testing.T) {
+	client, err := New()
+	require.NoError(t, err)
+
+	respRead, err := client.GetSecurityIssuesRead(nil)
+	require.EqualError(t, err, "security issues read request is required")
+	assert.Nil(t, respRead)
+
+	respCount, err := client.GetSecurityIssuesCount(nil)
+	require.EqualError(t, err, "security issues count request is required")
+	assert.Nil(t, respCount)
+
+	respGroups, err := client.GetSecurityIssueGroups(nil)
+	require.EqualError(t, err, "security issue groups request is required")
+	assert.Nil(t, respGroups)
+
+	respGroupsCount, err := client.GetSecurityIssueGroupsCount(nil)
+	require.EqualError(t, err, "security issue groups count request is required")
+	assert.Nil(t, respGroupsCount)
+
+	respIssue, err := client.GetSecurityIssue(nil)
+	require.EqualError(t, err, "security issue request is required")
+	assert.Nil(t, respIssue)
+}

--- a/get_security_issues_test.go
+++ b/get_security_issues_test.go
@@ -1,0 +1,150 @@
+package wallarm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSecurityIssuesReadUsesPOSTBodyTokenAndClientID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/security_issues", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req GetSecurityIssuesRead
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 130, req.ClientID)
+		assert.Equal(t, "test-token", req.Token)
+		require.NotNil(t, req.Filter)
+		assert.Equal(t, []string{"open"}, req.Filter.State)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":101,"client_id":130,"severity":"high","state":"open","name":"SQL injection","host":"shop.example.com"}]`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.GetSecurityIssuesRead(&GetSecurityIssuesRead{
+		ClientID: 130,
+		Limit:    20,
+		Filter: &GetSecurityIssuesFilter{
+			State: []string{"open"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, 101, resp[0].ID)
+	assert.Equal(t, "high", resp[0].Severity)
+}
+
+func TestGetSecurityIssuesCountUsesPOSTBodyTokenAndClientID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/security_issues/count", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req GetSecurityIssuesCount
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 130, req.ClientID)
+		assert.Equal(t, "test-token", req.Token)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":7}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.GetSecurityIssuesCount(&GetSecurityIssuesCount{ClientID: 130})
+	require.NoError(t, err)
+	assert.Equal(t, 7, resp.Count)
+}
+
+func TestGetSecurityIssueGroupsUsesPOSTBodyTokenAndClientID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/security_issues/groups", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req GetSecurityIssueGroups
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 130, req.ClientID)
+		assert.Equal(t, "test-token", req.Token)
+		require.NotNil(t, req.OrderBy)
+		assert.Equal(t, "severity", req.OrderBy.Name)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"group_id":"sqli","title":"SQL injection","severity":"high","security_issues_count":3,"states":{"open":2,"closed":1,"marked_false":0}}]`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.GetSecurityIssueGroups(&GetSecurityIssueGroups{
+		ClientID: 130,
+		OrderBy: &GetSecurityIssuesOrderBy{
+			Name:      "severity",
+			Direction: "desc",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	assert.Equal(t, "sqli", resp[0].GroupID)
+	assert.Equal(t, 3, resp[0].SecurityIssuesCount)
+}
+
+func TestGetSecurityIssueUsesGETQueryTokenAndClientID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/security_issues/101", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "130", r.URL.Query().Get("client_id"))
+		assert.Equal(t, "test-token", r.URL.Query().Get("token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":101,"client_id":130,"severity":"high","state":"open","name":"SQL injection","description":"demo issue"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := New(
+		UsingBaseURL(server.URL),
+		Headers(http.Header{"X-WallarmAPI-Token": []string{"test-token"}}),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.GetSecurityIssue(&GetSecurityIssue{
+		ID:       101,
+		ClientID: 130,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 101, resp.ID)
+	assert.Equal(t, "demo issue", resp.Description)
+}

--- a/ip_list.go
+++ b/ip_list.go
@@ -156,9 +156,10 @@ func (api *api) IPListReadByRuleType(listType IPListType, clientID int, ruleType
 func (api *api) IPListSearch(listType IPListType, clientID int, ruleType string, query string) ([]IPRule, error) {
 	uri := fmt.Sprintf("/v1/blocklist/clients/%d/groups", clientID)
 
-	filter := fmt.Sprintf(`{"rule_type":[%q],"list":%q,"query":%q}`, ruleType, string(listType), query)
 	q := url.Values{}
-	q.Set("filter", filter)
+	q.Add("filter[rule_type][]", ruleType)
+	q.Set("filter[list]", string(listType))
+	q.Set("filter[query]", query)
 	q.Set("limit", "1")
 	q.Set("offset", "0")
 

--- a/ip_list_test.go
+++ b/ip_list_test.go
@@ -1,196 +1,169 @@
 package wallarm
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestAllowlistRead(t *testing.T) {
+func TestIPListRead_GroupedEntries(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
+	requests := 0
+	mux.HandleFunc("/v1/blocklist/clients/17/groups", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		assert.Equal(t, "block", r.URL.Query().Get("filter[list]"))
+		assert.ElementsMatch(t, []string{"subnet", "proxy_type", "datacenter", "location"}, r.URL.Query()["filter[rule_type][]"])
+		assert.Equal(t, "1", r.URL.Query().Get("limit"))
+		assert.Equal(t, fmt.Sprintf("%d", requests), r.URL.Query().Get("offset"))
+
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"body": {"objects": [{"id": 2, "rule_type": "subnet", "list": "allow", "values": ["10.0.0.0/8"]}]}}`)
+		if requests == 0 {
+			fmt.Fprint(w, `{"body":{"objects":[{"id":7,"client_id":17,"rule_type":"subnet","list":"block","created_at":1770000000,"expired_at":0,"application_ids":[0],"reason":"manual block","author_user_id":11,"values":["1.2.3.4"],"status":"enabled"}]}}`)
+		} else if requests == 1 {
+			fmt.Fprint(w, `{"body":{"objects":[{"id":8,"client_id":17,"rule_type":"location","list":"block","created_at":1770000100,"expired_at":1771000000,"application_ids":[12],"reason":"geo block","author_user_id":12,"values":["RU"],"status":"enabled"}]}}`)
+		} else {
+			fmt.Fprint(w, `{"body":{"objects":[]}}`)
+		}
+		requests++
 	})
 
-	res, err := client.AllowlistRead(8649)
-	assert.NoError(t, err)
-	assert.Len(t, res, 1)
-	assert.Equal(t, "allow", res[0].List)
-}
-
-func TestGraylistRead(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"body": {"objects": [{"id": 3, "rule_type": "subnet", "list": "gray", "values": ["192.168.0.0/16"]}]}}`)
-	})
-
-	res, err := client.GraylistRead(8649)
-	assert.NoError(t, err)
-	assert.Len(t, res, 1)
-	assert.Equal(t, "gray", res[0].List)
-}
-
-func TestIPListReadByRuleType(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"body": {"objects": [{"id": 4, "rule_type": "location", "list": "block", "values": ["CN"]}]}}`)
-	})
-
-	res, err := client.IPListReadByRuleType(DenylistType, 8649, []string{"location"}, 1000)
-	assert.NoError(t, err)
-	assert.Len(t, res, 1)
-	assert.Equal(t, "location", res[0].RuleType)
-}
-
-func TestIPListSearch(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"body": {"objects": [{"id": 5, "rule_type": "subnet", "list": "block", "values": ["1.2.3.4/32"]}]}}`)
-	})
-
-	res, err := client.IPListSearch(DenylistType, 8649, "subnet", "1.2.3.4")
-	assert.NoError(t, err)
-	assert.Len(t, res, 1)
-}
-
-func TestIPListRead(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{
-			"body": {
-				"objects": [{
-					"id": 1,
-					"client_id": 8649,
-					"rule_type": "subnet",
-					"list": "block",
-					"expired_at": 0,
-					"values": ["1.2.3.4/32"]
-				}]
-			}
-		}`)
-	})
-
-	res, err := client.DenylistRead(8649)
-	assert.NoError(t, err)
-	assert.Len(t, res, 1)
-	assert.Equal(t, "subnet", res[0].RuleType)
-}
-
-func TestAllowlistCreate(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/access_rules", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"status": 200, "body": null}`)
-	})
-
-	err := client.AllowlistCreate(8649, AccessRuleCreateRequest{
-		Reason: "test",
-		Rules:  []AccessRuleEntry{{RulesType: "ip_range", Values: []string{"5.6.7.8/32"}}},
-	})
-	assert.NoError(t, err)
-}
-
-func TestAllowlistDelete(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "DELETE", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"status": 200, "body": null}`)
-	})
-
-	err := client.AllowlistDelete(8649, []AccessRuleDeleteEntry{{RuleType: "subnet", IDs: []int{1}}})
-	assert.NoError(t, err)
-}
-
-func TestGraylistCreate(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/access_rules", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"status": 200, "body": null}`)
-	})
-
-	err := client.GraylistCreate(8649, AccessRuleCreateRequest{
-		Reason: "test",
-		Rules:  []AccessRuleEntry{{RulesType: "ip_range", Values: []string{"9.8.7.6/32"}}},
-	})
-	assert.NoError(t, err)
-}
-
-func TestGraylistDelete(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "DELETE", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"status": 200, "body": null}`)
-	})
-
-	err := client.GraylistDelete(8649, []AccessRuleDeleteEntry{{RuleType: "subnet", IDs: []int{1}}})
-	assert.NoError(t, err)
-}
-
-func TestDenylistCreate(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/v1/blocklist/clients/8649/access_rules", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"status": 200, "body": null}`)
-	})
-
-	err := client.DenylistCreate(8649, AccessRuleCreateRequest{
-		Reason: "test",
-		Rules: []AccessRuleEntry{
-			{RulesType: "ip_range", Values: []string{"1.2.3.4/32"}},
+	actual, err := client.IPListRead(DenylistType, 17, 1)
+	require.NoError(t, err)
+	require.Len(t, actual, 2)
+	assert.Equal(t, []IPRule{
+		{
+			ID:             7,
+			ClientID:       17,
+			RuleType:       "subnet",
+			List:           "block",
+			CreatedAt:      1770000000,
+			ExpiredAt:      0,
+			ApplicationIDs: []int{0},
+			Reason:         "manual block",
+			AuthorUserID:   11,
+			Values:         []string{"1.2.3.4"},
+			Status:         "enabled",
 		},
-	})
-	assert.NoError(t, err)
+		{
+			ID:             8,
+			ClientID:       17,
+			RuleType:       "location",
+			List:           "block",
+			CreatedAt:      1770000100,
+			ExpiredAt:      1771000000,
+			ApplicationIDs: []int{12},
+			Reason:         "geo block",
+			AuthorUserID:   12,
+			Values:         []string{"RU"},
+			Status:         "enabled",
+		},
+	}, actual)
+	assert.Equal(t, 3, requests)
 }
 
-func TestDenylistDelete(t *testing.T) {
+func TestIPListSearch_UsesBracketedFilterQuery(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v1/blocklist/clients/8649/groups", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "DELETE", r.Method)
+	mux.HandleFunc("/v1/blocklist/clients/42/groups", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		assert.Equal(t, []string{"location"}, r.URL.Query()["filter[rule_type][]"])
+		assert.Equal(t, "allow", r.URL.Query().Get("filter[list]"))
+		assert.Equal(t, "RU", r.URL.Query().Get("filter[query]"))
+		assert.Empty(t, r.URL.Query().Get("filter"))
+		assert.Equal(t, "1", r.URL.Query().Get("limit"))
+		assert.Equal(t, "0", r.URL.Query().Get("offset"))
+
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, `{"status": 200, "body": null}`)
+		fmt.Fprint(w, `{"body":{"objects":[{"id":9,"client_id":42,"rule_type":"location","list":"allow","created_at":1770000200,"expired_at":0,"application_ids":[0],"reason":"allow geo","author_user_id":13,"values":["RU"],"status":"enabled"}]}}`)
 	})
 
-	err := client.DenylistDelete(8649, []AccessRuleDeleteEntry{
-		{RuleType: "subnet", IDs: []int{1}},
+	actual, err := client.IPListSearch(AllowlistType, 42, "location", "RU")
+	require.NoError(t, err)
+	require.Len(t, actual, 1)
+	assert.Equal(t, IPRule{
+		ID:             9,
+		ClientID:       42,
+		RuleType:       "location",
+		List:           "allow",
+		CreatedAt:      1770000200,
+		ExpiredAt:      0,
+		ApplicationIDs: []int{0},
+		Reason:         "allow geo",
+		AuthorUserID:   13,
+		Values:         []string{"RU"},
+		Status:         "enabled",
+	}, actual[0])
+}
+
+func TestIPListCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := AccessRuleCreateRequest{
+		List:           GraylistType,
+		Force:          true,
+		Reason:         "temporary review",
+		ApplicationIDs: []int{0, 12},
+		ExpiredAt:      1772000000,
+		Rules: []AccessRuleEntry{{
+			RulesType: "subnet",
+			Values:    []string{"10.0.0.0/8"},
+		}},
+	}
+
+	mux.HandleFunc("/v1/blocklist/clients/23/access_rules", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var actual AccessRuleCreateRequest
+		require.NoError(t, json.Unmarshal(body, &actual))
+		assert.Equal(t, expected, actual)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{"status":200}`)
 	})
-	assert.NoError(t, err)
+
+	err := client.IPListCreate(23, expected)
+	require.NoError(t, err)
+}
+
+func TestIPListDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := AccessRuleDeleteRequest{
+		Rules: []AccessRuleDeleteEntry{
+			{RuleType: "subnet", IDs: []int{7, 8}},
+			{RuleType: "location", IDs: []int{9}},
+		},
+	}
+
+	mux.HandleFunc("/v1/blocklist/clients/23/groups", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var actual AccessRuleDeleteRequest
+		require.NoError(t, json.Unmarshal(body, &actual))
+		assert.Equal(t, expected, actual)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{"status":200}`)
+	})
+
+	err := client.IPListDelete(23, expected.Rules)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- add attack read/count/ip support plus hit detail/raw helpers and attack cursor paging fields
- add activity log filters, list, and single-event read client support
- expand security issues coverage with count, groups, single-issue reads, and keep IP list search query encoding aligned with current API contract
- rebase the changes on current wallarm/wallarm-go master and keep go test ./... green

## Validation
- go test ./...